### PR TITLE
Rename Mac Os X to MacOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
           </div>
           <div class="card mb-4 box-shadow">
             <div class="card-header">
-              <h4 class="my-0 font-weight-normal">Mac Os X</h4>
+              <h4 class="my-0 font-weight-normal">MacOS</h4>
             </div>
             <div class="card-body">
               


### PR DESCRIPTION
Since Apple's Mac OS 11 (Big Sur), Mac OS X would apply to Non-Big Sur