### PR TITLE
Switch back to GitHub Pages hosting

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-libresprite.org


### PR DESCRIPTION
Disable redirect to `libresprite.org` as site is down (temporary?)