### PR TITLE
Update Mac required version on Downloads

### DIFF
--- a/pages/downloads.html
+++ b/pages/downloads.html
@@ -61,7 +61,7 @@
               <i class="fa fa-apple fa-5x icons-dowloads" ></i>
               <ul class="list-unstyled mt-3 mb-4">
                 <b>System Requirements:</b>
-                <li>OS: Mac OS X 10.11.4 </li> 
+                <li>OS: Mac OS 11 or above </li> 
                 <li>Processor:  Intel or ARM </li>
                 <li>RAM: 1 GB </li>
                 <li></li>


### PR DESCRIPTION
I have updated the Mac OS required version on the Downloads page.

Solves - https://github.com/LibreSprite/LibreSprite/issues/417 